### PR TITLE
Update examples to generate kubernetes compliant deployments

### DIFF
--- a/lessons/lesson1/example1.jsonnet
+++ b/lessons/lesson1/example1.jsonnet
@@ -21,7 +21,7 @@
         containers: [
           {
             name: 'httpd',
-            image: 'httpd:2.4',
+            image: 'httpd:2.3',
           },
         ],
       },

--- a/lessons/lesson1/example1.jsonnet
+++ b/lessons/lesson1/example1.jsonnet
@@ -6,7 +6,17 @@
   },
   spec: {
     replicas: 1,
+    selector: {
+      matchLabels: {
+        component: 'server',
+      },
+    },
     template: {
+      metadata: {
+          labels: {
+            component: 'server',
+          },
+        },
       spec: {
         containers: [
           {

--- a/lessons/lesson1/example2.jsonnet
+++ b/lessons/lesson1/example2.jsonnet
@@ -7,7 +7,17 @@ local webserver = {
     },
     spec: {
       replicas: replicas,
+      selector: {
+        matchLabels: {
+          component: 'server',
+        },
+      },
       template: {
+        metadata: {
+          labels: {
+            component: 'server',
+          },
+        },
         spec: {
           containers: [
             {

--- a/lessons/lesson1/example2.jsonnet
+++ b/lessons/lesson1/example2.jsonnet
@@ -22,7 +22,7 @@ local webserver = {
           containers: [
             {
               name: 'httpd',
-              image: 'httpd:2.4',
+              image: 'httpd:2.3',
             },
           ],
         },

--- a/lessons/lesson1/example3.jsonnet
+++ b/lessons/lesson1/example3.jsonnet
@@ -6,13 +6,24 @@ local webserver = {
       name: name,
     },
     spec: {
+      selector: {
+        matchLabels: {
+          component: 'server',
+        },
+      },
       replicas: replicas,
       template: {
+        metadata: {
+            labels: {
+              component: 'server',
+            },
+        },
+
         spec: {
           containers: [
             {
               name: 'httpd',
-              image: 'httpd:2.4',
+              image: 'httpd:2.3',
             },
           ],
         },
@@ -38,4 +49,4 @@ local webserver = {
 };
 
 webserver.new('wonderful-webserver')
-+ webserver.withImage('httpd:2.5')
++ webserver.withImage('httpd:2.4')

--- a/lessons/lesson1/example4.jsonnet
+++ b/lessons/lesson1/example4.jsonnet
@@ -7,20 +7,28 @@ local webserver = {
       image: 'httpd:2.4',
     },
 
-    deployment: {
-      apiVersion: 'apps/v1',
-      kind: 'Deployment',
-      metadata: {
-        name: name,
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: name,
+    },
+    spec: {
+      selector: {
+        matchLabels: {
+          component: 'server',
+        },
       },
-      spec: {
-        replicas: replicas,
-        template: {
-          spec: {
-            containers: [
-              base.container,
-            ],
+      replicas: replicas,
+      template: {
+        metadata: {
+          labels: {
+            component: 'server',
           },
+        },
+        spec: {
+          containers: [
+            base.container,
+          ],
         },
       },
     },
@@ -32,4 +40,4 @@ local webserver = {
 };
 
 webserver.new('wonderful-webserver')
-+ webserver.withImage('httpd:2.5')
++ webserver.withImage('httpd:2.4')

--- a/lessons/lesson1/example6.jsonnet
+++ b/lessons/lesson1/example6.jsonnet
@@ -9,21 +9,28 @@ local webserver = {
         containerPort: 80,
       }],
     },
-
-    deployment: {
-      apiVersion: 'apps/v1',
-      kind: 'Deployment',
-      metadata: {
-        name: name,
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: name,
+    },
+    spec: {
+      selector: {
+        matchLabels: {
+          component: 'server',
+        },
       },
-      spec: {
-        replicas: replicas,
-        template: {
-          spec: {
-            containers: [
-              base.container,
-            ],
+      replicas: replicas,
+      template: {
+        metadata: {
+          labels: {
+            component: 'server',
           },
+        },
+        spec: {
+          containers: [
+            base.container,
+          ],
         },
       },
     },
@@ -35,7 +42,7 @@ local webserver = {
 };
 
 webserver.new('wonderful-webserver')
-+ webserver.withImage('httpd:2.5')
++ webserver.withImage('httpd:2.4')
 + {
   container+: {
     ports: [{

--- a/lessons/lesson1/example7.jsonnet
+++ b/lessons/lesson1/example7.jsonnet
@@ -9,21 +9,29 @@ local webserver = {
         containerPort: 80,
       }],
     },
+    apiVersion: 'apps/v1',
 
-    deployment: {
-      apiVersion: 'apps/v1',
-      kind: 'Deployment',
-      metadata: {
-        name: name,
+    kind: 'Deployment',
+    metadata: {
+      name: name,
+    },
+    spec: {
+      selector: {
+        matchLabels: {
+          component: 'server',
+        },
       },
-      spec: {
-        replicas: replicas,
-        template: {
-          spec: {
-            containers: [
-              base.container,
-            ],
+      replicas: replicas,
+      template: {
+        metadata: {
+          labels: {
+            component: 'server',
           },
+        },
+        spec: {
+          containers: [
+            base.container,
+          ],
         },
       },
     },
@@ -39,5 +47,5 @@ local webserver = {
 };
 
 webserver.new('wonderful-webserver')
-+ webserver.withImage('httpd:2.5')
++ webserver.withImage('httpd:2.4')
 + webserver.withImagePullPolicy()


### PR DESCRIPTION
As I work through the examples, I like getting some hands on experience deploying the changes to a kubernetes cluster. 
I've created a local [kind](kind.sigs.k8s.io/) cluster to test changes against by executing the following commend:

```sh
jsonnet example1.jsonnet | k apply -f -
```
Issues resolved:
- selector and labels are missing(k8s rejects deployment)
- examples 4/6/7 nested the deployment in a `deployment` object which k8s will reject
- `httpd:2.5` does not exist :smile:, so I changed it to `2.3` for the default and called `withImage('httpd:2.4')`


I ignored the following:
- `example5.jsonnet` isn't referenced, can probably be deleted?
- updated pitfall examples

I'll submit separate PR's later lessons as I get to them. Overall, I found the first lesson to be pretty clear where the value add is with `jsonnet` and liked how you introduced `mixins` and other concepts. 
 

